### PR TITLE
feat(app): add POST /signups endpoint

### DIFF
--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -1,5 +1,32 @@
 class SignupsController < ApplicationController
+  INCOGNIA_INSTALLATION_ID_HEADER = 'Incognia-Installation-ID'.freeze
+  EN_US_LOCALE = 'en-US'.freeze
+
   rescue_from Incognia::APIError, with: :handle_api_errors
+
+  def create
+    installation_id = request.headers[INCOGNIA_INSTALLATION_ID_HEADER]
+    address = params.require(:structured_address)
+      .permit(
+        :country_name,
+        :country_code,
+        :state,
+        :city,
+        :borough,
+        :street,
+        :number,
+        :postal_code
+      ).to_h
+    address.merge!(locale: EN_US_LOCALE) # For simplicity sake
+
+    assessment = incognia_api.register_signup(
+      installation_id: installation_id, address: address
+    ).to_h
+
+    signup = assessment.slice(:id)
+
+    render json: signup
+  end
 
   def show
     assessment = incognia_api.get_signup_assessment(signup_id: params[:id]).to_h
@@ -12,9 +39,16 @@ class SignupsController < ApplicationController
   private
 
   def handle_api_errors(exception)
-    return render nothing: true, status: 404 if exception.status == 404
+    Rails.logger.error exception.message
 
-    render nothing: true, status: 500
+    case exception.status
+    when 404
+      render nothing: true, status: 404
+    when 400
+      render json: exception.errors, status: 422
+    else
+      render nothing: true, status: 500
+    end
   end
 
   def incognia_api

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :signups, only: :show
+  resources :signups, only: [:create, :show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/spec/requests/signups_spec.rb
+++ b/spec/requests/signups_spec.rb
@@ -1,8 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe "Signups", type: :request do
+  shared_examples_for 'handle Incognia API errors' do
+    context 'when API returns 404' do
+      before do
+        allow(incognia_api).to receive(method)
+          .and_raise(Incognia::APIError.new('', status: 404))
+      end
+
+      it "returns http not found" do
+        dispatch_request
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when API returns 400' do
+      before do
+        allow(incognia_api).to receive(method)
+          .and_raise(Incognia::APIError.new('', status: 400, body: error_message))
+      end
+      let(:error_message) { { errors: 'Some error'}.to_json }
+
+      it "returns http 422" do
+        dispatch_request
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when API returns other error' do
+      before do
+        allow(incognia_api).to receive(method)
+          .and_raise(Incognia::APIError.new(''))
+      end
+
+      it "returns http internal error" do
+        dispatch_request
+
+        expect(response).to have_http_status(:error)
+      end
+    end
+  end
+
   describe "GET /show" do
-    subject(:request_signup) { get "/signups/#{id}" }
+    subject(:dispatch_request) { get "/signups/#{id}" }
 
     let(:id) { SecureRandom.uuid }
     let(:signup) { OpenStruct.new(id: id) }
@@ -16,44 +58,93 @@ RSpec.describe "Signups", type: :request do
     end
     let(:incognia_api) { instance_double(Incognia::Api) }
 
+    it 'requests Incognia with informed id' do
+      expect(incognia_api).to receive(:get_signup_assessment)
+        .with(signup_id: id)
+        .and_return(signup)
+
+      dispatch_request
+    end
+
     it "returns http success" do
-      request_signup
+      dispatch_request
 
       expect(response).to have_http_status(:success)
     end
 
     it "returns signup as JSON" do
-      request_signup
+      dispatch_request
 
       expect(response.body).to eq(signup.to_h.to_json)
     end
 
-    context 'when API returns 404' do
-      before do
-        allow(incognia_api).to receive(:get_signup_assessment)
-          .with(signup_id: id)
-          .and_raise(Incognia::APIError.new('', status: 404))
-      end
+    it_behaves_like 'handle Incognia API errors' do
+      let(:method) { :get_signup_assessment }
+    end
+  end
 
-      it "returns http not found" do
-        request_signup
+  describe "POST /create" do
+    subject(:dispatch_request) do
+      post "/signups", params: { structured_address: address }, headers: headers
+    end
+    let(:address) do
+      {
+        country_name:"United States of America",
+        country_code:"US",
+        state:"NY",
+        city:"New York City",
+        borough:"Manhattan",
+        street:"W 34th St.",
+        number:"20",
+        postal_code:"10001"
+      }
+    end
+    let(:headers) do
+      {
+        "ACCEPT" => "application/json",
+        SignupsController::INCOGNIA_INSTALLATION_ID_HEADER => installation_id
+      }
+    end
+    let(:installation_id) { SecureRandom.hex }
 
-        expect(response).to have_http_status(:not_found)
-      end
+    let(:signup) { OpenStruct.new(id: SecureRandom.uuid) }
+
+    before do
+      allow(Incognia::Api).to receive(:new).and_return(incognia_api)
+
+      allow(incognia_api).to receive(:register_signup)
+        .with(
+          installation_id: installation_id,
+          address: hash_including(address)
+        )
+        .and_return(signup)
+    end
+    let(:incognia_api) { instance_double(Incognia::Api) }
+
+    it 'requests Incognia with default locale' do
+      enriched_address = address.merge(locale: SignupsController::EN_US_LOCALE)
+
+      expect(incognia_api).to receive(:register_signup)
+        .with(installation_id: installation_id, address: enriched_address)
+        .and_return(signup)
+
+      dispatch_request
     end
 
-    context 'when API returns other error' do
-      before do
-        allow(incognia_api).to receive(:get_signup_assessment)
-          .with(signup_id: id)
-          .and_raise(Incognia::APIError.new(''))
-      end
+    it "returns http success" do
+      dispatch_request
 
-      it "returns http internal error" do
-        request_signup
+      expect(response).to have_http_status(:success)
+    end
 
-        expect(response).to have_http_status(:error)
-      end
+    it "returns registered signup as JSON" do
+      dispatch_request
+
+      expect(response.body).to eq(signup.to_h.to_json)
+    end
+
+    it_behaves_like 'handle Incognia API errors' do
+      let(:method) { :register_signup }
     end
   end
 end


### PR DESCRIPTION
Also improves error handling and reuse of specs.

>       when API returns 404
>         returns http not found
>       when API returns 400
>         returns http 422
>       when API returns other error
>         returns http internal error



```
➜  incognia-demo-api git:(feat/get-signup) ✗ curl --request POST -v \                                                                                
  --url http://localhost:3000/signups \
  --header 'Accept: application/json' \
  --header 'Incognia-Installation-ID: xalalaID' \
  --header 'Content-Type: application/json' \
  --data '{
   "structured_address":{
      "country_name":"United States of America",
      "country_code":"US",
      "state":"NY",
      "city":"New York City",
      "borough":"Manhattan",
      "street":"W 34th St.",
      "number":"20",
      "postal_code":"10001", "evil": "xalala"
   }
}'

Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:3000...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3000 (#0)
> POST /signups HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.68.0
> Accept: application/json
> Incognia-Installation-ID: xalalaID
> Content-Type: application/json
> Content-Length: 285
> 
* upload completely sent off: 285 out of 285 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 0
< X-Content-Type-Options: nosniff
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Referrer-Policy: strict-origin-when-cross-origin
< Content-Type: application/json; charset=utf-8
< Vary: Accept
< ETag: W/"e091a7dcdc3ba03b6801ed33ea1fdcf3"
< Cache-Control: max-age=0, private, must-revalidate
< X-Request-Id: 31b953a5-d305-4f47-88be-1d12659ff790
< X-Runtime: 1.836870
< Server-Timing: start_processing.action_controller;dur=0.9052734375, unpermitted_parameters.action_controller;dur=0.609375, process_action.action_controller;dur=1780.02783203125
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
{"id":"1733c602-96b3-4ee4-92b8-9f973750aa76"}% 
```