### PR TITLE
refact(app/serializers): move serialization logic from controller

### DIFF
--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -26,7 +26,7 @@ class SignupsController < ApplicationController
     signup = form.submit
 
     if signup
-      render json: { id: signup.incognia_signup_id }
+      render json: SignupSerializer.new(signup: signup).to_json
     else
       render json: { errors: form.errors.to_hash }, status: 422
     end
@@ -35,7 +35,7 @@ class SignupsController < ApplicationController
   def show
     signup = Signups::GetReassessment.call(incognia_signup_id: params[:id])
 
-    render json: { id: signup.incognia_signup_id }
+    render json: SignupSerializer.new(signup: signup).to_json
   end
 
   private

--- a/app/serializers/base_serializer.rb
+++ b/app/serializers/base_serializer.rb
@@ -1,0 +1,11 @@
+class BaseSerializer
+  include ActiveModel::Serialization
+
+  def to_hash
+    self.serializable_hash.compact
+  end
+
+  def to_json
+    self.to_hash.to_json
+  end
+end

--- a/app/serializers/signup_serializer.rb
+++ b/app/serializers/signup_serializer.rb
@@ -1,0 +1,18 @@
+class SignupSerializer < BaseSerializer
+
+  def initialize(signup:)
+    @signup = signup
+  end
+
+  def attributes
+    { 'id' => nil }
+  end
+
+  def id
+    signup.incognia_signup_id
+  end
+
+  private
+
+  attr_reader :signup
+end

--- a/spec/requests/signups_spec.rb
+++ b/spec/requests/signups_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Signups", type: :request do
     it "returns signup as JSON" do
       dispatch_request
 
-      expect(response.body).to eq({ id: signup.incognia_signup_id }.to_json)
+      expect(response.body).to eq(SignupSerializer.new(signup: signup).to_json)
     end
 
     it_behaves_like 'handle Incognia API errors' do
@@ -130,7 +130,7 @@ RSpec.describe "Signups", type: :request do
       it "returns registered signup as JSON" do
         dispatch_request
 
-        expect(response.body).to eq({ id: signup.incognia_signup_id }.to_json)
+        expect(response.body).to eq(SignupSerializer.new(signup: signup).to_json)
       end
 
       it_behaves_like 'handle Incognia API errors' do

--- a/spec/serializers/signup_serializer_spec.rb
+++ b/spec/serializers/signup_serializer_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe SignupSerializer, type: :serializer do
+  subject(:serialized) { described_class.new(signup: signup).to_hash }
+  let(:signup) { build(:signup) }
+
+  it 'serializes signup' do
+    expect(serialized).to eq('id' => signup.incognia_signup_id)
+  end
+end


### PR DESCRIPTION
Introduce a serialization strategy based on ActiveModel::Serialization module.

Ref: https://api.rubyonrails.org/classes/ActiveModel/Serialization.html