### PR TITLE
feat(Signin): add passwordless signin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "bootsnap", require: false
 # gem "rack-cors"
 
 # Incognia library
-gem "incognia_api", '~> 0.2', require: 'incognia'
+gem "incognia_api", '~> 0.3', require: 'incognia'
 
 # Ruby interface to the PostgreSQL
 gem 'pg', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,8 +104,8 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -117,7 +117,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    incognia_api (0.2.0)
+    incognia_api (0.3.0)
       faraday
       faraday_middleware
     io-console (0.5.11)
@@ -133,7 +133,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.5.1)
-    multipart-post (2.1.1)
+    multipart-post (2.2.3)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -226,7 +226,7 @@ DEPENDENCIES
   dotenv-rails (~> 2.7.6)
   factory_bot_rails (~> 6.2)
   faker (~> 2.21)
-  incognia_api (~> 0.2)
+  incognia_api (~> 0.3)
   pg (~> 1.4)
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,20 @@
 class ApplicationController < ActionController::API
+  INCOGNIA_INSTALLATION_ID_HEADER = 'Incognia-Installation-ID'.freeze
+
+  rescue_from Incognia::APIError, with: :handle_api_errors
+
+  private
+
+  def handle_api_errors(exception)
+    Rails.logger.error exception.message
+
+    case exception.status
+    when 404
+      render nothing: true, status: 404
+    when 400
+      render json: exception.errors, status: 422
+    else
+      render nothing: true, status: 500
+    end
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,21 @@
+class SessionsController < ApplicationController
+  def create
+    account_id = params.fetch(:account_id)
+
+    user = User.find_by!(account_id: account_id)
+
+    form = Signin::PasswordlessForm.new(
+      user: user,
+      installation_id: request.headers[INCOGNIA_INSTALLATION_ID_HEADER],
+    )
+    user = form.submit
+
+    if user
+      render json: SessionSerializer.new(user: user).to_json
+    elsif form.errors.any?
+      render json: { errors: form.errors.to_hash }, status: :unprocessable_entity
+    else
+      render json: { otp_required: true }, status: :unauthorized
+    end
+  end
+end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -1,8 +1,4 @@
 class SignupsController < ApplicationController
-  INCOGNIA_INSTALLATION_ID_HEADER = 'Incognia-Installation-ID'.freeze
-
-  rescue_from Incognia::APIError, with: :handle_api_errors
-
   def create
     signup_params = params.permit(
       :account_id, :email,
@@ -36,20 +32,5 @@ class SignupsController < ApplicationController
     user = Signups::GetReassessment.call(incognia_signup_id: params[:id])
 
     render json: SignupSerializer.new(user: user).to_json
-  end
-
-  private
-
-  def handle_api_errors(exception)
-    Rails.logger.error exception.message
-
-    case exception.status
-    when 404
-      render nothing: true, status: 404
-    when 400
-      render json: exception.errors, status: 422
-    else
-      render nothing: true, status: 500
-    end
   end
 end

--- a/app/forms/signin/passwordless_form.rb
+++ b/app/forms/signin/passwordless_form.rb
@@ -1,0 +1,25 @@
+module Signin
+  class PasswordlessForm
+    include ActiveModel::Model
+
+    attr_accessor :user, :installation_id
+
+    validates :user, presence: true
+    validates :installation_id, presence: true
+
+    def submit
+      assessment = IncogniaApi.instance.register_login(
+        account_id: user.account_id,
+        installation_id: installation_id,
+      )
+
+      return user if assessment.risk_assessment.to_sym == :low_risk
+
+      code = GenerateSigninCode.call(user: user)
+      SessionMailer.otp_email(recipient: user.email, otp_code: code)
+        .deliver_later
+
+      nil
+    end
+  end
+end

--- a/app/forms/signin/passwordless_form.rb
+++ b/app/forms/signin/passwordless_form.rb
@@ -8,6 +8,8 @@ module Signin
     validates :installation_id, presence: true
 
     def submit
+      return if invalid?
+
       assessment = IncogniaApi.instance.register_login(
         account_id: user.account_id,
         installation_id: installation_id,

--- a/app/mailers/session_mailer.rb
+++ b/app/mailers/session_mailer.rb
@@ -1,0 +1,7 @@
+class SessionMailer < ApplicationMailer
+  def otp_email(recipient:, otp_code:)
+    @otp_code = otp_code
+
+    mail to: recipient, subject: 'Temporary Incognia sign in code'
+  end
+end

--- a/app/models/signin_code.rb
+++ b/app/models/signin_code.rb
@@ -1,0 +1,3 @@
+class SigninCode < ApplicationRecord
+  belongs_to :user
+end

--- a/app/serializers/session_serializer.rb
+++ b/app/serializers/session_serializer.rb
@@ -1,0 +1,27 @@
+class SessionSerializer < BaseSerializer
+  def initialize(user:)
+    @user = user
+  end
+
+  def attributes
+    { 'signup_id' => nil, 'signup_timestamp' => nil, 'structured_address' => nil }
+  end
+
+  def signup_id
+    user.incognia_signup_id
+  end
+
+  def signup_timestamp
+    user.created_at.to_i
+  end
+
+  def structured_address
+    return if user.address.blank?
+
+    user.address.fetch('structured_address')
+  end
+
+  private
+
+  attr_reader :user
+end

--- a/app/services/signin/generate_signin_code.rb
+++ b/app/services/signin/generate_signin_code.rb
@@ -1,0 +1,19 @@
+module Signin
+  class GenerateSigninCode
+    OTP_LENGTH = 20.freeze
+    EXPIRATION_TIME_IN_MINUTES = 5.freeze
+
+    class << self
+      def call(user:)
+        code = SecureRandom.base64(OTP_LENGTH)
+
+        SigninCode.create(
+          code: code, user: user,
+          expires_at: Time.now + EXPIRATION_TIME_IN_MINUTES.minutes
+        )
+
+        code
+      end
+    end
+  end
+end

--- a/app/views/session_mailer/otp_email.text.erb
+++ b/app/views/session_mailer/otp_email.text.erb
@@ -1,0 +1,1 @@
+Copy and paste this code to sign in the Incognia app: <%= @otp_code %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,4 +47,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.active_job.queue_adapter = :test
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   resources :signups, only: [:create, :show]
+
+  post :signin, to: 'sessions#create'
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/db/migrate/20220708092517_create_signin_codes.rb
+++ b/db/migrate/20220708092517_create_signin_codes.rb
@@ -1,0 +1,11 @@
+class CreateSigninCodes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :signin_codes do |t|
+      t.string :code
+      t.timestamp :expires_at
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_08_085738) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_08_092517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "signin_codes", force: :cascade do |t|
+    t.string "code"
+    t.datetime "expires_at", precision: nil
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_signin_codes_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.json "address"
@@ -23,4 +32,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_08_085738) do
     t.string "email"
   end
 
+  add_foreign_key "signin_codes", "users"
 end

--- a/lib/incognia_api.rb
+++ b/lib/incognia_api.rb
@@ -4,7 +4,8 @@ class IncogniaApi
   include Singleton
 
   extend Forwardable
-  def_delegators :incognia_api, :register_signup, :get_signup_assessment
+  def_delegators :incognia_api, :register_signup, :get_signup_assessment,
+    :register_login
 
   private
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,4 +16,9 @@ FactoryBot.define do
     end
     incognia_signup_id { SecureRandom.uuid }
   end
+
+  factory :signin_code do
+    code { SecureRandom.base64(20) }
+    expires_at { 2.minutes_from_now }
+  end
 end

--- a/spec/forms/signin/passwordless_form_spec.rb
+++ b/spec/forms/signin/passwordless_form_spec.rb
@@ -83,5 +83,29 @@ RSpec.describe Signin::PasswordlessForm, type: :model do
       it_behaves_like 'generate and send otp code to email', :high_risk
       it_behaves_like 'generate and send otp code to email', :unknown_risk
     end
+
+    context 'when attributes are invalid' do
+      let(:params) { {} }
+
+      it 'does not request Incognia' do
+        expect(IncogniaApi.instance).to_not receive(:register_login)
+
+        submit
+      end
+
+      it 'does not generate a signin code' do
+        expect(Signin::GenerateSigninCode).to_not receive(:call)
+
+        submit
+      end
+
+      it 'does not send email with generated code' do
+        expect(SessionMailer).to_not receive(:otp_email)
+      end
+
+      it 'returns falsy' do
+        expect(submit).to be_falsy
+      end
+    end
   end
 end

--- a/spec/forms/signin/passwordless_form_spec.rb
+++ b/spec/forms/signin/passwordless_form_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe Signin::PasswordlessForm, type: :model do
+  subject(:form) { described_class.new(attrs) }
+  let(:attrs) { {} }
+
+  context 'validations' do
+    it { should validate_presence_of(:user) }
+    it { should validate_presence_of(:installation_id) }
+  end
+
+  describe '#submit' do
+    subject(:submit) { form.submit }
+
+    context 'when attributes are valid' do
+      let(:attrs) do
+        {
+          user: user,
+          installation_id: installation_id,
+        }
+      end
+      let(:user) { build(:user) }
+      let(:installation_id) { SecureRandom.uuid }
+
+      before do
+        allow(IncogniaApi.instance).to receive(:register_login)
+          .with(account_id: user.account_id, installation_id: installation_id)
+          .and_return(login_assessment)
+      end
+      let(:login_assessment) { OpenStruct.new(risk_assessment: risk_assessment) }
+      let(:risk_assessment) { [:low_risk, :unknown_risk, :high_risk].sample }
+
+      it 'requests Incognia with account_id and installation_id' do
+        expect(IncogniaApi.instance).to receive(:register_login)
+          .with(account_id: user.account_id, installation_id: installation_id)
+          .and_return(login_assessment)
+
+        submit
+      end
+
+      context 'and Incognia API returns low risk' do
+        let(:risk_assessment) { 'low_risk' }
+
+        it 'returns the user' do
+          expect(submit).to eq(user)
+        end
+      end
+
+      shared_examples_for 'generate and send otp code to email' do |risk_assessment|
+        context "when Incognia API returns #{risk_assessment}" do
+          let(:risk_assessment) { risk_assessment }
+          let(:code) { SecureRandom.base64(20) }
+          let(:message_delivery) { instance_double(ActionMailer::MessageDelivery) }
+
+          before do
+            allow(Signin::GenerateSigninCode).to receive(:call).with(user: user).
+              and_return(code)
+          end
+
+          it 'invokes generate signin code service' do
+            expect(Signin::GenerateSigninCode).to receive(:call).with(user: user).
+              and_return(code)
+
+            submit
+          end
+
+          it 'sends email with generated code' do
+            expect(SessionMailer).to receive(:otp_email)
+              .with(recipient: user.email, otp_code: code)
+              .and_return(message_delivery)
+
+            expect(message_delivery).to receive(:deliver_later)
+
+            submit
+          end
+
+          it 'returns nil' do
+            expect(submit).to be_nil
+          end
+        end
+      end
+
+      it_behaves_like 'generate and send otp code to email', :high_risk
+      it_behaves_like 'generate and send otp code to email', :unknown_risk
+    end
+  end
+end

--- a/spec/lib/incognia_api_spec.rb
+++ b/spec/lib/incognia_api_spec.rb
@@ -1,49 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe IncogniaApi, type: :lib do
-  before do
-    allow(ENV).to receive(:[]).with('INCOGNIA_CLIENT_ID').and_return(client_id)
-    allow(ENV).to receive(:[]).with('INCOGNIA_SECRET')
-      .and_return(client_secret)
-
-    allow(Incognia::Api).to receive(:new)
-      .with(client_id: client_id, client_secret: client_secret)
-      .and_return(api)
-  end
-  let(:api) { instance_double(Incognia::Api) }
-  let(:client_id) { SecureRandom.uuid }
-  let(:client_secret) { SecureRandom.uuid }
+  subject { described_class.instance }
 
   describe '.instance' do
+    before do
+      allow(ENV).to receive(:[]).with('INCOGNIA_CLIENT_ID').and_return(client_id)
+      allow(ENV).to receive(:[]).with('INCOGNIA_SECRET')
+        .and_return(client_secret)
+
+    end
+    let(:client_id) { SecureRandom.uuid }
+    let(:client_secret) { SecureRandom.uuid }
+
+    it 'initializes Incognia api library with propert env vars' do
+      expect(Incognia::Api).to receive(:new)
+        .with(client_id: client_id, client_secret: client_secret)
+
+      IncogniaApi.instance.incognia_api
+    end
+
     it 'returns the same instance of IncogniaApi' do
       expect(IncogniaApi.instance).to be_an(IncogniaApi)
       expect(IncogniaApi.instance).to eq(IncogniaApi.instance)
     end
   end
 
-  describe '#register_signup' do
-    # Using clone to avoid mock leaking due to singleton
-    subject(:wrapper) { described_class.clone.instance }
-    let(:installation_id) { SecureRandom.uuid }
-
-    it 'delegates to Incognia::Api' do
-      expect(api).to receive(:register_signup)
-        .with(installation_id: installation_id)
-
-      wrapper.register_signup(installation_id: installation_id)
-    end
-  end
-
-  describe '#get_signup_assessment' do
-    # Using clone to avoid mock leaking due to singleton
-    subject(:wrapper) { described_class.clone.instance }
-    let(:signup_id) { SecureRandom.uuid }
-
-    it 'delegates to Incognia::Api' do
-      expect(api).to receive(:get_signup_assessment)
-        .with(signup_id: signup_id)
-
-      wrapper.get_signup_assessment(signup_id: signup_id)
-    end
-  end
+  it { should delegate_method(:register_signup).to(:incognia_api) }
+  it { should delegate_method(:get_signup_assessment).to(:incognia_api) }
+  it { should delegate_method(:register_login).to(:incognia_api) }
 end

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe SessionMailer, type: :mailer do
+  subject(:mailer) { described_class }
+
+  describe '#otp_email' do
+    subject(:mail) do
+      mailer.otp_email(recipient: recipient, otp_code: otp_code).deliver_now
+    end
+    let(:recipient) { Faker::Internet.email }
+    let(:otp_code) { SecureRandom.base64(20) }
+
+    it 'sends to the recipient' do
+      expect(mail.to).to eq([recipient])
+    end
+
+    it 'correctly sets the subject' do
+      expect(mail.subject).to eq('Temporary Incognia sign in code')
+    end
+
+    it 'assigns the otp code' do
+      expect(mail.body.encoded).to include(otp_code)
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :request do
+  describe "POST /create" do
+    subject(:dispatch_request) do
+      post "/signin", params: params, headers: headers
+    end
+    let(:params) { { account_id: user.account_id } }
+    let(:user) { create(:user) }
+    let(:headers) do
+      {
+        "ACCEPT" => "application/json",
+        SignupsController::INCOGNIA_INSTALLATION_ID_HEADER => installation_id
+      }
+    end
+    let(:installation_id) { SecureRandom.hex }
+
+
+    context 'when validations succeed' do
+      before do
+        allow(Signin::PasswordlessForm).to receive(:new)
+          .with(user: user, installation_id: installation_id)
+          .and_return(form)
+      end
+      let(:form) { instance_double(Signin::PasswordlessForm, errors: []) }
+
+      context 'and the form returns the user' do
+        before { allow(form).to receive(:submit).and_return(user) }
+
+        it "invokes passwordless signin form" do
+          allow(Signin::PasswordlessForm).to receive(:new)
+            .with(user: user, installation_id: installation_id)
+            .and_return(form)
+
+          expect(form).to receive(:submit)
+
+          dispatch_request
+        end
+
+        it "returns http success" do
+          dispatch_request
+
+          expect(response).to have_http_status(:success)
+        end
+
+        it "returns registered signup as JSON" do
+          dispatch_request
+
+          expect(response.body).to eq(SessionSerializer.new(user: user).to_json)
+        end
+      end
+
+      context 'but the form returns nil' do
+        before { allow(form).to receive(:submit).and_return(nil) }
+
+        it "returns http unauthorized" do
+          dispatch_request
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+
+        it "returns otp required message" do
+          dispatch_request
+
+          parsed_body = JSON.parse(response.body).deep_symbolize_keys
+          expect(parsed_body).to have_key(:otp_required)
+          expect(parsed_body.dig(:otp_required)).to eq(true)
+        end
+      end
+
+      it_behaves_like 'handle Incognia API errors' do
+        let(:service) { form }
+        let(:method) { :submit }
+      end
+    end
+
+    context 'when validations fails' do
+      before do
+        allow_any_instance_of(Signin::PasswordlessForm).to receive(:submit)
+          .and_return(nil)
+
+        allow_any_instance_of(Signin::PasswordlessForm).to receive(:errors)
+          .and_return(form_errors)
+      end
+      let(:form_errors) do
+        Signin::PasswordlessForm
+          .new
+          .errors
+          .tap { |e| e.add(attribute, message) }
+      end
+      let(:attribute) { :user }
+      let(:message) { 'cant be blank' }
+
+      it "returns http unprocessable entity" do
+        dispatch_request
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns detailed errors" do
+        dispatch_request
+
+        parsed_body = JSON.parse(response.body).deep_symbolize_keys
+        expect(parsed_body).to have_key(:errors)
+        expect(parsed_body.dig(:errors, attribute)).to include(message)
+      end
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Sessions", type: :request do
     end
     let(:installation_id) { SecureRandom.hex }
 
-
     context 'when validations succeed' do
       before do
         allow(Signin::PasswordlessForm).to receive(:new)

--- a/spec/requests/signups_spec.rb
+++ b/spec/requests/signups_spec.rb
@@ -1,48 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe "Signups", type: :request do
-  shared_examples_for 'handle Incognia API errors' do
-    context 'when API returns 404' do
-      before do
-        allow(service).to receive(method)
-          .and_raise(Incognia::APIError.new('', status: 404))
-      end
-
-      it "returns http not found" do
-        dispatch_request
-
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context 'when API returns 400' do
-      before do
-        allow(service).to receive(method)
-          .and_raise(Incognia::APIError.new('', status: 400, body: error_message))
-      end
-      let(:error_message) { { errors: 'Some error'}.to_json }
-
-      it "returns http 422" do
-        dispatch_request
-
-        expect(response).to have_http_status(422)
-      end
-    end
-
-    context 'when API returns other error' do
-      before do
-        allow(service).to receive(method)
-          .and_raise(Incognia::APIError.new(''))
-      end
-
-      it "returns http internal error" do
-        dispatch_request
-
-        expect(response).to have_http_status(:error)
-      end
-    end
-  end
-
   describe "GET /show" do
     subject(:dispatch_request) { get "/signups/#{user.incognia_signup_id}" }
     let(:user) { create(:user) }

--- a/spec/serializers/session_serializer_spec.rb
+++ b/spec/serializers/session_serializer_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe SessionSerializer, type: :serializer do
+  subject(:serialized) { described_class.new(user: user).to_hash }
+  let(:user) { create(:user) }
+
+  it 'serializes login with its user info' do
+    expect(serialized).to eq(
+      {
+        'signup_id' => user.incognia_signup_id,
+        'signup_timestamp' => user.created_at.to_i,
+        'structured_address' => user.address['structured_address']
+      }
+    )
+  end
+
+  context 'when user does not have address' do
+    before { user.update(address: nil) }
+
+    it 'serializes login with its user info without address' do
+      expect(serialized).to eq(
+        {
+          'signup_id' => user.incognia_signup_id,
+          'signup_timestamp' => user.created_at.to_i,
+        }
+      )
+    end
+  end
+end

--- a/spec/services/signin/generate_signin_code_spec.rb
+++ b/spec/services/signin/generate_signin_code_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Signin::GenerateSigninCode, type: :service do
+  describe '.call' do
+    subject(:generate) do
+      described_class.call(user: user)
+    end
+    let(:user) { create(:user) }
+
+    before do
+      allow(SecureRandom).to receive(:base64).with(described_class::OTP_LENGTH).
+        and_return(code)
+    end
+    let(:code) { Faker::Alphanumeric.alphanumeric }
+
+    it 'creates a sigin code associated with the user' do
+      expect { generate }.to change(SigninCode, :count).by(1)
+
+      generated_code = SigninCode.last
+      expect(generated_code.code).to eq(code)
+      expect(generated_code.user).to eq(user)
+      expect(generated_code.expires_at). to be_within(
+        1.second
+      ).of(
+        Time.now + described_class::EXPIRATION_TIME_IN_MINUTES.minutes
+      )
+    end
+
+    it "returns the generated code" do
+      expect(generate).to eq(code)
+    end
+  end
+end

--- a/spec/services/signin/generate_signin_code_spec.rb
+++ b/spec/services/signin/generate_signin_code_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Signin::GenerateSigninCode, type: :service do
     end
     let(:code) { Faker::Alphanumeric.alphanumeric }
 
-    it 'creates a sigin code associated with the user' do
+    it 'creates a signin code associated with the user' do
       expect { generate }.to change(SigninCode, :count).by(1)
 
       generated_code = SigninCode.last

--- a/spec/support/shared_examples/handle_incognia_api_errors.rb
+++ b/spec/support/shared_examples/handle_incognia_api_errors.rb
@@ -1,0 +1,41 @@
+shared_examples_for 'handle Incognia API errors' do
+  context 'when API returns 404' do
+    before do
+      allow(service).to receive(method)
+        .and_raise(Incognia::APIError.new('', status: 404))
+    end
+
+    it "returns http not found" do
+      dispatch_request
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'when API returns 400' do
+    before do
+      allow(service).to receive(method)
+        .and_raise(Incognia::APIError.new('', status: 400, body: error_message))
+    end
+    let(:error_message) { { errors: 'Some error'}.to_json }
+
+    it "returns http 422" do
+      dispatch_request
+
+      expect(response).to have_http_status(422)
+    end
+  end
+
+  context 'when API returns other error' do
+    before do
+      allow(service).to receive(method)
+        .and_raise(Incognia::APIError.new(''))
+    end
+
+    it "returns http internal error" do
+      dispatch_request
+
+      expect(response).to have_http_status(:error)
+    end
+  end
+end


### PR DESCRIPTION
Allow passwordless sign-in based on Incognia API and fall back to OTP if frictionless sign-in is not possible.

Request: 
```bash
curl --request POST -v \
  --url localhost:3000/signin \
  --header 'Accept: application/json' \
  --header 'Authorization: eGFsYWxhOnRva2Vu\n' \
  --header 'Incognia-Installation-ID: some-installation-id' \
  --header 'Content-Type: application/json' \
  --data '{
    "account_id": "anVsaWFuYS5sdWNlbmFAaW5jb2duaWEuY29t"
}'


# HTTP/1.1 401 Unauthorized
{"otp_required":true}
```

Email containing the OTP code:
```
From: no-reply@incognia.com
To: juliana.lucena@incognia.com
Message-ID: <62c89818b0d75_2d5ed524545548e@INLOCO-1K54423.mail>
Subject: Temporary Incognia sign in code
Mime-Version: 1.0
Content-Type: text/plain;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

Copy and paste this code to sign in the Incognia app: yt2gN1z4g0DxX/psZXXlY/ZgGz8=
```