### PR TITLE
feat(Signin): add action to validate OTP signin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ This API responds to the below endpoints:
 
 * Register signup: `POST /signups`
 * Reassess signup: `GET /signups/:id`
+* Signin: `POST /signin`
+  * This endpoint uses Incognia API to decide between frictionlessly sign in the user or sending an OTP through email.
+* Validate signin OTP: `POST /signin/validate_otp`
+
 
 ## How to run this API locally?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,17 +5,37 @@ class SessionsController < ApplicationController
     user = User.find_by!(account_id:)
 
     form = Signin::PasswordlessForm.new(
-      user: user,
+      user:,
       installation_id: request.headers[INCOGNIA_INSTALLATION_ID_HEADER],
     )
-    user = form.submit
+    logged_in_user = form.submit
 
-    if user
-      render json: SessionSerializer.new(user:)
+    if logged_in_user
+      render json: SessionSerializer.new(user: logged_in_user)
     elsif form.errors.any?
       render json: { errors: form.errors.to_hash }, status: :unprocessable_entity
     else
       render json: { otp_required: true }, status: :unauthorized
+    end
+  end
+
+  def validate_otp
+    signin_params = params
+      .permit(:account_id, :code)
+      .to_hash
+      .symbolize_keys
+
+    user = User.find_by!(account_id: signin_params.fetch(:account_id))
+
+    form = Signin::OtpForm.new(user:, code: signin_params.fetch(:code))
+    logged_in_user = form.submit
+
+    if logged_in_user
+      render json: SessionSerializer.new(user: logged_in_user)
+    elsif form.errors.any?
+      render json: { errors: form.errors.to_hash }, status: :unprocessable_entity
+    else
+      render nothing: true, status: :unauthorized
     end
   end
 end

--- a/app/forms/signin/otp_form.rb
+++ b/app/forms/signin/otp_form.rb
@@ -1,0 +1,39 @@
+module Signin
+  class OtpForm
+    include ActiveModel::Model
+
+    attr_accessor :user, :code
+
+    validates :user, presence: true
+    validates :code, presence: true
+    validate :code_existence
+    validate :code_usage, if: :signin_code
+    validate :code_expiration, if: :signin_code
+
+    def submit
+      return if invalid?
+
+      signin_code.update(used_at: Time.now)
+
+      user
+    end
+
+    private
+
+    def signin_code
+      @signin_code ||= SigninCode.find_by(user:, code:)
+    end
+
+    def code_existence
+      errors.add(:code, :invalid) unless signin_code
+    end
+
+    def code_usage
+      errors.add(:code, :already_used) if signin_code.used_at
+    end
+
+    def code_expiration
+      errors.add(:code, :expired) if signin_code.expires_at < Time.now
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,5 +29,226 @@
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.
 
+---
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validation failed: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
+  activemodel:
+    errors:
+      models:
+        signin/otp_form:
+          attributes:
+            code:
+              already_used: "Given code was already used"
+              expired: "Given code expired"
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+    prompts:
+      second: Second
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: 'Validation failed: %{errors}'
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   resources :signups, only: [:create, :show]
 
   post :signin, to: 'sessions#create'
+  scope :signin do
+    post :validate_otp, to: 'sessions#validate_otp'
+  end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20220711171819_add_used_at_to_signin_codes.rb
+++ b/db/migrate/20220711171819_add_used_at_to_signin_codes.rb
@@ -1,0 +1,5 @@
+class AddUsedAtToSigninCodes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :signin_codes, :used_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_08_092517) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_11_171819) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_08_092517) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "used_at", precision: nil
     t.index ["user_id"], name: "index_signin_codes_on_user_id"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,7 +18,8 @@ FactoryBot.define do
   end
 
   factory :signin_code do
+    user
     code { SecureRandom.base64(20) }
-    expires_at { 2.minutes_from_now }
+    expires_at { 2.minutes.from_now }
   end
 end

--- a/spec/forms/signin/otp_form_spec.rb
+++ b/spec/forms/signin/otp_form_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe Signin::OtpForm, type: :model do
+  subject(:form) { described_class.new(attrs) }
+  let(:attrs) { { user: signin_code.user, code: signin_code.code } }
+  let(:signin_code) { create(:signin_code) }
+
+  context 'validations' do
+    it { should validate_presence_of(:user) }
+    it { should validate_presence_of(:code) }
+
+    describe 'code existence' do
+      before { attrs.merge!(code: Faker::Lorem.word) }
+
+      it 'is expected to validate that :code is invalid' do
+        expect(form).to be_invalid
+        expect(form.errors).to have_key(:code)
+        expect(form.errors[:code]).to include(I18n.t('errors.messages.invalid'))
+      end
+    end
+
+    describe 'code usage' do
+      before { signin_code.update(used_at: 5.hours.ago) }
+
+      it 'is expected to validate that :code is already used' do
+        expect(form).to be_invalid
+        expect(form.errors).to have_key(:code)
+        expect(form.errors[:code]).to include(
+          I18nHelpers.model_attribute_error(
+            klass: form.class,
+            attribute: :code,
+            error_key: :already_used
+          )
+        )
+      end
+    end
+
+    describe 'code expiration' do
+      before { signin_code.update(expires_at: 5.hours.ago) }
+
+      it 'is expected to validate that :code is expired' do
+        expect(form).to be_invalid
+        expect(form.errors).to have_key(:code)
+        expect(form.errors[:code]).to include(
+          I18nHelpers.model_attribute_error(
+            klass: form.class,
+            attribute: :code,
+            error_key: :expired
+          )
+        )
+      end
+    end
+  end
+
+  describe '#submit' do
+    subject(:submit) { form.submit }
+
+    context 'when attributes are valid' do
+      it 'updates sigin code used timestamp' do
+        expect { submit }.to change { signin_code.reload.used_at }
+      end
+
+      it 'returns the logged in user' do
+        expect(submit).to eq(signin_code.user)
+      end
+    end
+
+    context 'when attributes are invalid' do
+      let(:attrs) { {} }
+
+      it 'does not update sigin code used timestamp' do
+        expect { submit }.to_not change { signin_code.used_at }
+      end
+
+      it 'returns falsy' do
+        expect(submit).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/forms/signin/otp_form_spec.rb
+++ b/spec/forms/signin/otp_form_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Signin::OtpForm, type: :model do
     subject(:submit) { form.submit }
 
     context 'when attributes are valid' do
-      it 'updates sigin code used timestamp' do
+      it 'updates signin code used timestamp' do
         expect { submit }.to change { signin_code.reload.used_at }
       end
 
@@ -68,7 +68,7 @@ RSpec.describe Signin::OtpForm, type: :model do
     context 'when attributes are invalid' do
       let(:attrs) { {} }
 
-      it 'does not update sigin code used timestamp' do
+      it 'does not update signin code used timestamp' do
         expect { submit }.to_not change { signin_code.used_at }
       end
 

--- a/spec/support/i18n_helper.rb
+++ b/spec/support/i18n_helper.rb
@@ -1,0 +1,9 @@
+module I18nHelpers
+  class << self
+    def model_attribute_error(klass:, attribute:, error_key:, value: nil)
+      prefix = "#{klass.i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes"
+
+      I18n.t("#{prefix}.#{attribute}.#{error_key}", value: value)
+    end
+  end
+end


### PR DESCRIPTION
Considers the following code validations:
* Existence (considering the informed `account_id`)
* Expiration
* Usage (was it already used?)

```bash
curl --request POST -v \    
  --url localhost:3000/signin/validate_otp \
  --header 'Accept: application/json' \
  --header 'Authorization: xalalaAuth\n' \
  --header 'Content-Type: application/json' \
  --data '{
    "account_id": "anVsaWFuYS5sdWNlbmFAaW5jb2duaWEuY29t",
    "code": "IiempWMXIXoc3TUgJH8kV3E7Wlo="
}'


# HTTP/1.1 200 OK
{
  "signup_id":"4ba6efab-b688-49da-8235-bc26d4278bf9",
  "signup_timestamp":1657563343,
  "structured_address":{
    "locale":"en-US",
    "country_name":"Brasil",
    "country_code":"BR",
    "state":"SP",
    "city":"São Paulo",
    "street":"Av. Paulista",
    "number":"1578",
    "postal_code":"01310200"
  }
}% 
```