### PR TITLE
feat(): add communication between mobile and web user

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end

--- a/app/channels/signin_channel.rb
+++ b/app/channels/signin_channel.rb
@@ -1,0 +1,8 @@
+class SigninChannel < ApplicationCable::Channel
+  def subscribed
+    signin_code = SigninCode.find_by(code: params[:code])
+    reject unless signin_code
+
+    stream_for signin_code
+  end
+end

--- a/app/forms/signin/code_validations.rb
+++ b/app/forms/signin/code_validations.rb
@@ -1,0 +1,26 @@
+module Signin
+  module CodeValidations
+    extend ActiveSupport::Concern
+
+    included do
+      validates :code, presence: true
+      validate :code_existence
+      validate :code_usage, if: :signin_code
+      validate :code_expiration, if: :signin_code
+    end
+
+    private
+
+    def code_existence
+      errors.add(:code, :invalid) unless signin_code
+    end
+
+    def code_usage
+      errors.add(:code, :already_used) if signin_code.used_at
+    end
+
+    def code_expiration
+      errors.add(:code, :expired) if signin_code.expires_at < Time.now
+    end
+  end
+end

--- a/app/javascript/controllers/signin_controller.js
+++ b/app/javascript/controllers/signin_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+import consumer from "channels/consumer"
+
+export default class extends Controller {
+  connect() {
+    this.subscription = consumer.subscriptions.create(
+      {
+        channel: "SigninChannel",
+        code: this.data.get("code"),
+      },
+      {
+        connected: this._connected.bind(this),
+        disconnected: this._disconnected.bind(this),
+        received: this._received.bind(this),
+      }
+    );
+  }
+
+  _connected() {}
+
+  _disconnected() {}
+
+  _received(data) {
+    fetch(data.url, {
+      method: "POST",
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: data['email'], code: data['code'] })
+    }).then(_ => {
+      window.location.reload();
+    });
+  }
+}

--- a/app/services/signin/generate_signin_code.rb
+++ b/app/services/signin/generate_signin_code.rb
@@ -4,14 +4,12 @@ module Signin
     EXPIRATION_TIME_IN_MINUTES = 5.freeze
 
     class << self
-      def call(user:)
+      def call(user:, expiration_time: nil)
         code = SecureRandom.base64(OTP_LENGTH)
+        expires_at = Time.now +
+          (expiration_time || EXPIRATION_TIME_IN_MINUTES.minutes)
 
-        SigninCode.create(
-          code:,
-          user:,
-          expires_at: Time.now + EXPIRATION_TIME_IN_MINUTES.minutes
-        )
+        SigninCode.create(code:, user:, expires_at:)
 
         code
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,16 @@
 Rails.application.routes.draw do
   namespace :web do
     resources :sessions, only: [:new, :create]
+    namespace :sessions do
+      post :validate_otp
+    end
   end
   resources :signups, only: [:create, :show]
 
   post :signin, to: 'sessions#create'
   scope :signin do
     post :validate_otp, to: 'sessions#validate_otp'
+    post :validate_qrcode, to: 'sessions#validate_qrcode'
   end
 
   root to: redirect('web')

--- a/spec/channels/signin_channel_spec.rb
+++ b/spec/channels/signin_channel_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe SigninChannel, type: :channel do
+  describe '#subscribed' do
+    let(:signin_code) { create(:signin_code) }
+
+    context 'when informed code exists' do
+      it 'streams for this code' do
+        subscribe code: signin_code.code
+
+        expect(subscription).to be_confirmed
+        expect(subscription).to have_stream_for(signin_code)
+      end
+    end
+
+    context 'when informed code does not exist' do
+      it 'rejects' do
+        subscribe code: build(:signin_code).code
+
+        expect(subscription).to be_rejected
+      end
+    end
+  end
+end

--- a/spec/forms/signin/otp_form_spec.rb
+++ b/spec/forms/signin/otp_form_spec.rb
@@ -7,49 +7,8 @@ RSpec.describe Signin::OtpForm, type: :model do
 
   context 'validations' do
     it { should validate_presence_of(:user) }
-    it { should validate_presence_of(:code) }
 
-    describe 'code existence' do
-      before { attrs.merge!(code: Faker::Lorem.word) }
-
-      it 'is expected to validate that :code is invalid' do
-        expect(form).to be_invalid
-        expect(form.errors).to have_key(:code)
-        expect(form.errors[:code]).to include(I18n.t('errors.messages.invalid'))
-      end
-    end
-
-    describe 'code usage' do
-      before { signin_code.update(used_at: 5.hours.ago) }
-
-      it 'is expected to validate that :code is already used' do
-        expect(form).to be_invalid
-        expect(form.errors).to have_key(:code)
-        expect(form.errors[:code]).to include(
-          I18nHelpers.model_attribute_error(
-            klass: form.class,
-            attribute: :code,
-            error_key: :already_used
-          )
-        )
-      end
-    end
-
-    describe 'code expiration' do
-      before { signin_code.update(expires_at: 5.hours.ago) }
-
-      it 'is expected to validate that :code is expired' do
-        expect(form).to be_invalid
-        expect(form.errors).to have_key(:code)
-        expect(form.errors[:code]).to include(
-          I18nHelpers.model_attribute_error(
-            klass: form.class,
-            attribute: :code,
-            error_key: :expired
-          )
-        )
-      end
-    end
+    it_behaves_like 'form with sign in code validations'
   end
 
   describe '#submit' do

--- a/spec/forms/signin/validate_mobile_token_form_spec.rb
+++ b/spec/forms/signin/validate_mobile_token_form_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Signin::ValidateMobileTokenForm, type: :model do
+  subject(:form) { described_class.new(attrs) }
+  let(:attrs) { { user: user, code: signin_code.code } }
+  let(:user) { create(:user) }
+  let(:signin_code) { create(:signin_code, user:) }
+
+  context 'validations' do
+    it { should validate_presence_of(:user) }
+
+    it_behaves_like 'form with sign in code validations'
+  end
+
+  describe '#submit' do
+    subject(:submit) { form.submit }
+
+    context 'when attributes are valid' do
+      before do
+        allow(Signin::GenerateSigninCode).to receive(:call)
+          .and_return(generated_code)
+      end
+      let(:generated_code) { build(:signin_code).code }
+
+      it 'updates signin code used timestamp' do
+        expect { submit }.to change { signin_code.reload.used_at }
+      end
+
+      it 'generates a new signin code with fast expiration' do
+        expect(Signin::GenerateSigninCode).to receive(:call).with(
+          user:,
+          expiration_time: described_class::EXPIRATION_TIME_IN_SECONDS
+        )
+
+        submit
+      end
+
+      it 'returns the new generated code' do
+        expect(submit).to eq(generated_code)
+      end
+
+      context 'and the code generation raises an error' do
+        before do
+          allow(Signin::GenerateSigninCode).to receive(:call)
+            .and_raise(ActiveRecord::ConnectionTimeoutError)
+        end
+
+        it 'leaves the sigin code unused' do
+          begin
+          submit
+          rescue ActiveRecord::ConnectionTimeoutError
+          end
+
+          signin_code.reload
+          expect(signin_code.used_at).to be_nil
+        end
+      end
+    end
+
+    context 'when attributes are invalid' do
+      let(:attrs) { {} }
+
+      it 'does not update signin code used timestamp' do
+        expect { submit }.to_not change { signin_code.used_at }
+      end
+
+      it 'does not generate a new signin code' do
+        expect(Signin::GenerateSigninCode).to_not receive(:call)
+
+        submit
+      end
+
+      it 'returns falsy' do
+        expect(submit).to be_falsy
+      end
+    end
+  end
+
+  context '#signin_code' do
+    it 'returns the signin code correspondent to informed code' do
+      expect(form.signin_code).to eq(signin_code)
+    end
+  end
+end

--- a/spec/requests/web/sessions_spec.rb
+++ b/spec/requests/web/sessions_spec.rb
@@ -53,4 +53,85 @@ RSpec.describe "Web::Sessions", type: :request do
       end
     end
   end
+
+  describe "POST /validate_otp" do
+    subject(:dispatch_request) { post "/web/sessions/validate_otp", params: }
+    let(:params) { { email: user.email, code: } }
+    let(:code) { signin_code.code }
+    let(:user) { signin_code.user }
+    let(:signin_code) { create(:signin_code) }
+
+    context 'when validations succeed' do
+      before do
+        allow(Signin::OtpForm).to receive(:new).with(user:, code:)
+          .and_return(form)
+      end
+      let(:form) { instance_double(Signin::OtpForm, errors: []) }
+
+      it "invokes otp signin form" do
+        expect(form).to receive(:submit)
+
+        dispatch_request
+      end
+
+      context 'and the form returns the logged in user' do
+        before { allow(form).to receive(:submit).and_return(user) }
+
+        it "sets the user session" do
+          expect_any_instance_of(Web::ApplicationController)
+            .to receive(:set_user_session).with(user)
+
+          dispatch_request
+        end
+
+        it "returns http success" do
+          dispatch_request
+
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context 'but the form returns nil' do
+        before { allow(form).to receive(:submit).and_return(nil) }
+
+        it "returns http unauthorized" do
+          dispatch_request
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
+
+    context 'when validations fails' do
+      before do
+        allow_any_instance_of(Signin::OtpForm).to receive(:submit)
+          .and_return(nil)
+
+        allow_any_instance_of(Signin::OtpForm).to receive(:errors)
+          .and_return(form_errors)
+      end
+      let(:form_errors) do
+        Signin::OtpForm
+          .new
+          .errors
+          .tap { |e| e.add(attribute, message) }
+      end
+      let(:attribute) { :user }
+      let(:message) { 'cant be blank' }
+
+      it "returns http unprocessable entity" do
+        dispatch_request
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns detailed errors" do
+        dispatch_request
+
+        parsed_body = JSON.parse(response.body).deep_symbolize_keys
+        expect(parsed_body).to have_key(:errors)
+        expect(parsed_body.dig(:errors, attribute)).to include(message)
+      end
+    end
+  end
 end

--- a/spec/services/signin/generate_signin_code_spec.rb
+++ b/spec/services/signin/generate_signin_code_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Signin::GenerateSigninCode, type: :service do
   describe '.call' do
-    subject(:generate) { described_class.call(user:) }
+    subject(:generate) { described_class.call(**attrs) }
+    let(:attrs) { { user: } }
     let(:user) { create(:user) }
 
     before do
@@ -26,6 +27,19 @@ RSpec.describe Signin::GenerateSigninCode, type: :service do
 
     it "returns the generated code" do
       expect(generate).to eq(code)
+    end
+
+    context 'when expiration time is informed' do
+      let(:attrs) { { user:, expiration_time: } }
+      let(:expiration_time) { rand(10).minutes }
+
+      it 'creates a signin code considering it' do
+        expect { generate }.to change(SigninCode, :count).by(1)
+
+        generated_code = SigninCode.last
+        expect(generated_code.expires_at). to be_within(1.second)
+          .of(Time.now + expiration_time)
+      end
     end
   end
 end

--- a/spec/support/shared_examples/form_with_sign_in_code_validations.rb
+++ b/spec/support/shared_examples/form_with_sign_in_code_validations.rb
@@ -1,0 +1,45 @@
+shared_examples_for 'form with sign in code validations' do
+  it { should validate_presence_of(:code) }
+
+  describe 'code existence' do
+    before { attrs.merge!(code: Faker::Lorem.word) }
+
+    it 'is expected to validate that :code is invalid' do
+      expect(form).to be_invalid
+      expect(form.errors).to have_key(:code)
+      expect(form.errors[:code]).to include(I18n.t('errors.messages.invalid'))
+    end
+  end
+
+  describe 'code usage' do
+    before { signin_code.update(used_at: 5.hours.ago) }
+
+    it 'is expected to validate that :code is already used' do
+      expect(form).to be_invalid
+      expect(form.errors).to have_key(:code)
+      expect(form.errors[:code]).to include(
+        I18nHelpers.model_attribute_error(
+          klass: form.class,
+          attribute: :code,
+          error_key: :already_used
+        )
+      )
+    end
+  end
+
+  describe 'code expiration' do
+    before { signin_code.update(expires_at: 5.hours.ago) }
+
+    it 'is expected to validate that :code is expired' do
+      expect(form).to be_invalid
+      expect(form.errors).to have_key(:code)
+      expect(form.errors[:code]).to include(
+        I18nHelpers.model_attribute_error(
+          klass: form.class,
+          attribute: :code,
+          error_key: :expired
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
- Open websocket connection with web user
- Add API endpoint to allow mobile to validate qr code.
- Add web endpoint to allow web user sign in after receiving websocket message

Flow:

1. Opens websocket connection when QR code is presented to the web user
2. Mobile sends read QR code to API /validate_qrcode endpoint
3. Web user receives a message through websocket
4. Web user sends a request to register their web session